### PR TITLE
Remove backup event listener class from annotation

### DIFF
--- a/gsrs-module-clinical-trials-spring-boot-autoconfigure/src/main/java/gov/hhs/gsrs/clinicaltrial/base/models/ClinicalTrialBase.java
+++ b/gsrs-module-clinical-trials-spring-boot-autoconfigure/src/main/java/gov/hhs/gsrs/clinicaltrial/base/models/ClinicalTrialBase.java
@@ -23,7 +23,9 @@ import javax.persistence.InheritanceType;
 @SuperBuilder
 @ToString
 @Backup
-@EntityListeners({AuditingEntityListener.class, GsrsEntityProcessorListener.class, IndexerEntityListener.class, BackupEntityProcessorListener.class})
+// (taking out of EventListners annotation for now and until substance indexing issue resolved)
+// BackupEntityProcessorListener.class
+@EntityListeners({AuditingEntityListener.class, GsrsEntityProcessorListener.class, IndexerEntityListener.class})
 public abstract class ClinicalTrialBase extends
         AbstractGsrsTablePerClassEntity
                 implements FetchableEntity, ForceUpdateDirtyMakerMixin {


### PR DESCRIPTION
CTs were getting added to the backup table; which should be normal but we are not using backup table for ct until indexing issues are resolved.